### PR TITLE
Document clangd setup for wider editor support

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,7 @@
   - [Debugging with gdb](./tools/decomp/gdb.md)
   - [Publishing](./tools/decomp/publish.md)
   - [CI/CD with GH Actions](./tools/decomp/gh-actions.md)
+  - [clangd](./tools/decomp/clangd.md)
 <!--- [I Use Windows, Get Me Out Of Here!](./tools/nix.md)-->
 
 # Reference

--- a/src/tools/decomp/clangd.md
+++ b/src/tools/decomp/clangd.md
@@ -1,0 +1,15 @@
+# Using clangd for language server features
+
+[clangd](https://clangd.llvm.org/) is a *language server* that can work with many editors.
+It adds smart features to your editor: code completion, compile errors, go-to-definition and more.
+
+## clangd setup
+
+To use clangd, you need to generate a `compile_commands.json` file. In the root of your Paper Mario directory, run this command:
+`ninja -t compdb > compile_commands.json`
+
+If you move the source directory, `compile_commands.json` will need to be regenerated. This is because it requires hardcoded, not relative, paths to work.
+
+## Editor setup
+
+See your editor's documentation for more details. Search "(your editor) lsp" to get started.


### PR DESCRIPTION
Right now, the docs recommend Visual Studio Code and the `papermario-dx` repository includes the necessary configuration for that editor. This PR adds a new page under the decomp section with instructions for generating a compilation database which allows for `clangd` to understand the project structure and provide smart editor features. `clangd` supports the Language Server Protocol which is widely supported among code editors.

The compilation database must be generated by the user because it only supports hardcoded paths. More information on the format here: https://clang.llvm.org/docs/JSONCompilationDatabase.html