### PR TITLE
fix texture archive name

### DIFF
--- a/src/content/docs/develop/maps/index.mdoc
+++ b/src/content/docs/develop/maps/index.mdoc
@@ -101,7 +101,7 @@ export MapSettings settings = {
     .entryList = &Entrances,
     .entryCount = ENTRY_COUNT(Entrances),
     .bgName = "kmr_bg",
-    .textures = "kmr_tex",
+    .textureArchive = "kmr",
 };
 ```
 


### PR DESCRIPTION
adjust the texture archive bit of the map guide to state the current definition of the name and syntax for the texture archive